### PR TITLE
Clear deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
   - osx
 
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,11 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-
-branches:
-  only:
-    - master
-    - /release-.*/
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 notifications:
   - provider: Email
@@ -17,9 +14,10 @@ notifications:
     on_build_status_changed: false
 
 install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        $env:JULIA_URL,
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -8,11 +8,11 @@ function get_terms(term::Term)
 end
 
 function get_real_coefficients(term::Term)
-    return (Array(Float64, 0), Array(Float64, 0))
+    return (Array{Float64}(0), Array{Float64}(0))
 end
 
 function get_complex_coefficients(term::Term)
-    return (Array(Float64, 0), Array(Float64, 0), Array(Float64, 0), Array(Float64, 0))
+    return (Array{Float64}(0), Array{Float64}(0), Array{Float64}(0), Array{Float64}(0))
 end
 
 function get_all_coefficients(term::Term)
@@ -23,13 +23,13 @@ end
 
 function get_value(term::Term, tau)
     coeffs = get_all_coefficients(term)
-    t = abs(tau)
+    t = abs.(tau)
     k = zeros(tau)
     for i in 1:length(coeffs[1])
-        k = k + coeffs[1][i] .* exp(-coeffs[2][i] .* t)
+        k .+= coeffs[1][i] .* exp.(-coeffs[2][i] .* t)
     end
     for i in 1:length(coeffs[3])
-        k = k + (coeffs[3][i].*cos(coeffs[6][i].*t) + coeffs[4][i].*sin(coeffs[6][i].*t)) .* exp(-coeffs[5][i].*t)
+        k .+= (coeffs[3][i] .* cos.(coeffs[6][i] .* t) .+ coeffs[4][i] .* sin.(coeffs[6][i] .* t)) .* exp.(-coeffs[5][i] .* t)
     end
     return k
 end
@@ -60,7 +60,7 @@ function length(term::Term)
 end
 
 function get_parameter_vector(term::Term)
-    return Array(Float64, 0)
+    return Array{Float64}(0)
 end
 
 function set_parameter_vector!(term::Term, vector::Array)
@@ -76,12 +76,12 @@ function get_terms(term::TermSum)
 end
 
 function get_all_coefficients(term_sum::TermSum)
-    a_real = Array(Float64, 0)
-    c_real = Array(Float64, 0)
-    a_complex = Array(Float64, 0)
-    b_complex = Array(Float64, 0)
-    c_complex = Array(Float64, 0)
-    d_complex = Array(Float64, 0)
+    a_real = Array{Float64}(0)
+    c_real = Array{Float64}(0)
+    a_complex = Array{Float64}(0)
+    b_complex = Array{Float64}(0)
+    c_complex = Array{Float64}(0)
+    d_complex = Array{Float64}(0)
     for term in term_sum.terms
         coeffs = get_all_coefficients(term)
 #        a_real = cat(1, a_real, coeffs[1])
@@ -139,8 +139,8 @@ function get_all_coefficients(term_sum::TermProduct)
 
     # First compute real terms
     nr = nr1 * nr2
-    ar = Array(Float64, nr)
-    cr = Array(Float64, nr)
+    ar = Array{Float64}(nr)
+    cr = Array{Float64}(nr)
     gen = product(zip(c1[1], c1[2]), zip(c2[1], c2[2]))
     for (i, ((aj, cj), (ak, ck))) in enumerate(gen)
         ar[i] = aj * ak
@@ -149,10 +149,10 @@ function get_all_coefficients(term_sum::TermProduct)
 
     # Then the complex terms
     nc = nr1 * nc2 + nc1 * nr2 + 2 * nc1 * nc2
-    ac = Array(Float64, nc)
-    bc = Array(Float64, nc)
-    cc = Array(Float64, nc)
-    dc = Array(Float64, nc)
+    ac = Array{Float64}(nc)
+    bc = Array{Float64}(nc)
+    cc = Array{Float64}(nc)
+    dc = Array{Float64}(nc)
 
     # real * complex
     gen = product(zip(c1[1], c1[2]), zip(c2[3:end]...))
@@ -260,7 +260,7 @@ end
 function get_real_coefficients(term::SHOTerm)
     Q = exp(term.log_Q)
     if Q >= 0.5
-        return Array(Float64, 0), Array(Float64, 0)
+        return Array{Float64}(0), Array{Float64}(0)
     end
     S0 = exp(term.log_S0)
     w0 = exp(term.log_omega0)
@@ -274,7 +274,7 @@ end
 function get_complex_coefficients(term::SHOTerm)
     Q = exp(term.log_Q)
     if Q < 0.5
-        return Array(Float64, 0), Array(Float64, 0), Array(Float64, 0), Array(Float64, 0)
+        return Array{Float64}(0), Array{Float64}(0), Array{Float64}(0), Array{Float64}(0)
     end
     S0 = exp(term.log_S0)
     w0 = exp(term.log_omega0)

--- a/src/test_cholesky.jl
+++ b/src/test_cholesky.jl
@@ -48,7 +48,7 @@ ntrial = 2
   N = N_test[itest]
 # Generate some random time data:
   t = sort(rand(N)).*100
-  y0 = sin(t)
+  y0 = sin.(t)
   kernel = RealTerm(log(aj[1]),log(cj[1]))
   for i=2:J0
     kernel = kernel + RealTerm(log(aj[i]),log(cj[i]))
@@ -77,7 +77,7 @@ ntrial = 2
   if N < 2000
     logdetK,K = full_solve(t,y0,aj,bj,cj,dj,yerr)
     println("Determinant: ",logdetK," ",logdet_test)
-    println("Vector: ",maximum(abs(\(K,y0)-apply_inverse(gp,y0))))
+    println("Vector: ", maximum(abs.((K \ y0) .- apply_inverse(gp, y0))))
   end
   println(N_test[itest]," ",time_complex[itest])
   time_prior = time_complex[itest]
@@ -90,7 +90,7 @@ ntrial = 2
 scatter(t,y0)
 plot(tpred,ypred)
 plot(tpred,ypred_full)
-println("Prediction error: ",maximum(abs(ypred-ypred_full)))
+println("Prediction error: ", maximum(abs.(ypred .- ypred_full)))
 
 #loglog(N_test,time_complex)
 data = readdlm("c_speed.txt",',')

--- a/src/test_cholesky_ldlt.jl
+++ b/src/test_cholesky_ldlt.jl
@@ -48,7 +48,7 @@ ntrial = 2
   N = N_test[itest]
 # Generate some random time data:
   t = sort(rand(N)).*100
-  y0 = sin(t)
+  y0 = sin.(t)
   kernel = RealTerm(log(aj[1]),log(cj[1]))
   for i=2:J0
     kernel = kernel + RealTerm(log(aj[i]),log(cj[i]))
@@ -77,7 +77,7 @@ ntrial = 2
   if N < 2000
     logdetK,K = full_solve(t,y0,aj,bj,cj,dj,yerr)
     println("Determinant: ",logdetK," ",logdet_test)
-    println("Vector: ",maximum(abs(\(K,y0)-apply_inverse_ldlt(gp,y0))))
+    println("Vector: ", maximum(abs.((K \ y0) .- apply_inverse_ldlt(gp, y0))))
   end
   println(N_test[itest]," ",time_complex[itest])
   time_prior = time_complex[itest]
@@ -90,7 +90,7 @@ ntrial = 2
 scatter(t,y0)
 plot(tpred,ypred)
 plot(tpred,ypred_full)
-println("Prediction error: ",maximum(abs(ypred-ypred_full)))
+println("Prediction error: ", maximum(abs.(ypred .- ypred_full)))
 
 #loglog(N_test,time_complex)
 data = readdlm("c_speed.txt",',')

--- a/test/test_solver.jl
+++ b/test/test_solver.jl
@@ -4,9 +4,9 @@ import celerite
 function test_solver()
     srand(42)
     N = 100
-    x = sort(10*rand(N))
-    y = sin(x)
-    yerr = 0.01 + 0.01*rand(N)
+    x = sort(10 .* rand(N))
+    y = sin.(x)
+    yerr = 0.01 .+ rand(N) ./ 100
 
     kernel = celerite.RealTerm(0.5, 1.0) + celerite.SHOTerm(0.1, 2.0, -0.5)
     gp = celerite.Celerite(kernel)

--- a/test/test_solver.jl
+++ b/test/test_solver.jl
@@ -1,7 +1,7 @@
 using Base.Test
 import celerite
 
-function test_solver(use_lapack)
+function test_solver()
     srand(42)
     N = 100
     x = sort(10*rand(N))
@@ -9,7 +9,7 @@ function test_solver(use_lapack)
     yerr = 0.01 + 0.01*rand(N)
 
     kernel = celerite.RealTerm(0.5, 1.0) + celerite.SHOTerm(0.1, 2.0, -0.5)
-    gp = celerite.Celerite(kernel, use_lapack=use_lapack)
+    gp = celerite.Celerite(kernel)
 
     K = celerite.get_matrix(gp, x)
     for n in 1:N
@@ -26,5 +26,4 @@ function test_solver(use_lapack)
     @test isapprox(ll, ll0)
 end
 
-test_solver(false)
-test_solver(true)
+test_solver()


### PR DESCRIPTION
Before digging into issue #9, I cleared most of deprecation warnings issued in Julia 0.6 and 0.7.

In particular, I changed `Array(T, n)` to `Array{T}(n)`, and used the [dot syntax for Vectorizing Functions](https://docs.julialang.org/en/stable/manual/functions/#man-dot-vectorizing).  This syntax was introduced in Julia 0.5, and will be even more powerful in Julia 0.6, as it drastically reduces memory allocations: https://julialang.org/blog/2017/01/moredots  I didn't everywhere this syntax, only where it was necessary to clear deprecation warnings, but consistently using the dot syntax might help in speeding up computation.

This pull request supersedes #8 (i.e., I cherry-picked the same commit by @dfm).