### PR TITLE
Clear again deprecation warnings

### DIFF
--- a/src/gp.jl
+++ b/src/gp.jl
@@ -322,7 +322,7 @@ function compute!(gp::Celerite, x, yerr = 0.0)
   @time gp.D,gp.Xp,gp.up,gp.phi = cholesky!(coeffs..., x, var, gp.Xp, gp.phi, gp.up, gp.D)
   gp.J = size(gp.Xp)[1]
 # Compute the log determinant (square the determinant of the Cholesky factor):
-  gp.logdet = 2.0*sum(log(gp.D))
+  gp.logdet = 2 * sum(log.(gp.D))
 #  gp.logdet = sum(log(gp.D))
   gp.x = x
   gp.computed = true
@@ -495,7 +495,8 @@ function full_solve(t::Vector,y0::Vector,aj::Vector,bj::Vector,cj::Vector,dj::Ve
   K = zeros(Float64,N,N)
   for i=1:N
     for j=1:N
-      K[i,j] = sum(aj.*exp(-cj.*abs(t[i]-t[j])).*cos(dj.*abs(t[i]-t[j]))+bj.*exp(-cj.*abs(t[i]-t[j])).*sin(dj.*abs(t[i]-t[j])))
+      abs_ti_tj = abs(t[i] - t[j])
+      K[i,j] = sum(aj .* exp.(-cj .* abs_ti_tj) .* cos.(dj .* abs_ti_tj) .+ bj .* exp.(-cj .* abs_ti_tj) .* sin.(dj .* abs_ti_tj))
     end
     K[i,i]=diag[i]
   end
@@ -505,7 +506,7 @@ function full_solve(t::Vector,y0::Vector,aj::Vector,bj::Vector,cj::Vector,dj::Ve
   for i=1:N
     K0[i,i] = diag[i]
   end
-  println("Semiseparable error: ",maximum(abs(K - K0)))
+  println("Semiseparable error: ", maximum(abs.(K - K0)))
   return logdet(K),K
 end
 
@@ -532,7 +533,7 @@ function predict_ldlt!(gp::Celerite, t, y, x)
     Q = zeros(J)
     X = zeros(J)
     pred = zeros(x)
-    
+
     # Forward pass
     m = 1
     while m < M && x[m] <= t[1]
@@ -540,22 +541,22 @@ function predict_ldlt!(gp::Celerite, t, y, x)
     end
     for n=1:N
         if n < N
-          tref = t[n+1] 
-        else 
+          tref = t[n+1]
+        else
           tref = t[N]
         end
-        Q[1:J_real] = (Q[1:J_real] + b[n]).*exp(-c_real.*(tref-t[n]))
-        Q[J_real+1:J_real+J_comp] += b[n].*cos(d_comp.*t[n])
-        Q[J_real+1:J_real+J_comp] = Q[J_real+1:J_real+J_comp].*exp(-c_comp.*(tref-t[n]))
-        Q[J_real+J_comp+1:J] += b[n].*sin(d_comp.*t[n])
-        Q[J_real+J_comp+1:J] = Q[J_real+J_comp+1:J].*exp(-c_comp.*(tref-t[n]))
+        Q[1:J_real] = (Q[1:J_real] .+ b[n]).* exp.(-c_real .* (tref - t[n]))
+        Q[J_real+1:J_real+J_comp] .= (Q[J_real+1:J_real+J_comp] .+ b[n] .* cos.(d_comp .* t[n])) .*
+            exp.(-c_comp .* (tref - t[n]))
+        Q[J_real+J_comp+1:J] .= (Q[J_real+J_comp+1:J] .+ b[n] .* sin.(d_comp .* t[n])) .*
+            exp.(-c_comp .* (tref - t[n]))
 
         while m < M+1 && (n == N || x[m] <= t[n+1])
-            X[1:J_real] = a_real.*exp(-c_real.*(x[m]-tref))
-            X[J_real+1:J_real+J_comp]  = a_comp.*exp(-c_comp.*(x[m]-tref)).*cos(d_comp.*x[m])
-            X[J_real+1:J_real+J_comp] += b_comp.*exp(-c_comp.*(x[m]-tref)).*sin(d_comp.*x[m])
-            X[J_real+J_comp+1:J]  = a_comp.*exp(-c_comp.*(x[m]-tref)).*sin(d_comp.*x[m])
-            X[J_real+J_comp+1:J] -= b_comp.*exp(-c_comp.*(x[m]-tref)).*cos(d_comp.*x[m])
+            X[1:J_real] = a_real .* exp.(-c_real .* (x[m] - tref))
+            X[J_real+1:J_real+J_comp] .= a_comp .* exp.(-c_comp .* (x[m] - tref)) .* cos.(d_comp .* x[m]) .+
+                b_comp .* exp.(-c_comp .* (x[m] - tref)) .* sin.(d_comp .* x[m])
+            X[J_real+J_comp+1:J] .= a_comp .* exp.(-c_comp .* (x[m] - tref)) .* sin.(d_comp .* x[m]) .-
+                b_comp .* exp.(-c_comp .* (x[m] - tref)) .* cos.(d_comp .* x[m])
 
             pred[m] = dot(X, Q)
             m += 1
@@ -570,28 +571,28 @@ function predict_ldlt!(gp::Celerite, t, y, x)
     fill!(Q,0.0)
     for n=N:-1:1
         if n > 1
-          tref = t[n-1] 
-        else 
+          tref = t[n-1]
+        else
           tref = t[1]
         end
-        Q[1:J_real] += b[n].*a_real
-        Q[1:J_real] = Q[1:J_real].*exp(-c_real.*(t[n]-tref))
-        Q[J_real+1:J_real+J_comp] += b[n].*a_comp.*cos(d_comp.*t[n])
-        Q[J_real+1:J_real+J_comp] += b[n].*b_comp.*sin(d_comp.*t[n])
-        Q[J_real+1:J_real+J_comp] = Q[J_real+1:J_real+J_comp].*exp(-c_comp.*(t[n]-tref))
-        Q[J_real+J_comp+1:J] += b[n].*a_comp.*sin(d_comp.*t[n])
-        Q[J_real+J_comp+1:J] -= b[n].*b_comp.*cos(d_comp.*t[n])
-        Q[J_real+J_comp+1:J] = Q[J_real+J_comp+1:J].*exp(-c_comp.*(t[n]-tref))
+        Q[1:J_real] .= (Q[1:J_real] .+ b[n] .* a_real) .*
+            exp.(-c_real .* (t[n]-tref))
+        Q[J_real+1:J_real+J_comp] .= (Q[J_real+1:J_real+J_comp] .+ b[n] .* a_comp .* cos.(d_comp .* t[n]) .+
+                                      b[n] .* b_comp .* sin.(d_comp .* t[n])) .*
+                                      exp.(-c_comp .* (t[n] - tref))
+        Q[J_real+J_comp+1:J] .= (Q[J_real+J_comp+1:J] .+ b[n] .* a_comp .* sin.(d_comp .* t[n]) .-
+                                 b[n] .* b_comp.*cos.(d_comp .* t[n])) .*
+                                 exp.(-c_comp .* (t[n] - tref))
 
         while m >= 1 && (n == 1 || x[m] > t[n-1])
-            X[1:J_real] = exp(-c_real.*(tref-x[m]))
-            X[J_real+1:J_real+J_comp] = exp(-c_comp.*(tref-x[m])).*cos(d_comp.*x[m])
-            X[J_real+J_comp+1:J] = exp(-c_comp.*(tref-x[m])).*sin(d_comp.*x[m])
+            X[1:J_real] .= exp.(-c_real .* (tref - x[m]))
+            X[J_real+1:J_real+J_comp] .= exp.(-c_comp .* (tref - x[m])) .* cos.(d_comp .* x[m])
+            X[J_real+J_comp+1:J] .= exp.(-c_comp .* (tref - x[m])) .* sin.(d_comp .* x[m])
 
             pred[m] += dot(X, Q)
             m -= 1
         end
-    end 
+    end
   return pred
 end
 
@@ -630,18 +631,18 @@ function predict!(gp::Celerite, t, y, x)
         else
           tref = t[N]
         end
-        Q[1:J_real] = (Q[1:J_real] + b[n]).*exp(-c_real.*(tref-t[n]))
-        Q[J_real+1:J_real+J_comp] += b[n].*cos(d_comp.*t[n])
-        Q[J_real+1:J_real+J_comp] = Q[J_real+1:J_real+J_comp].*exp(-c_comp.*(tref-t[n]))
-        Q[J_real+J_comp+1:J] += b[n].*sin(d_comp.*t[n])
-        Q[J_real+J_comp+1:J] = Q[J_real+J_comp+1:J].*exp(-c_comp.*(tref-t[n]))
+        Q[1:J_real] .= (Q[1:J_real] .+ b[n]) .* exp.(-c_real .* (tref .- t[n]))
+        Q[J_real+1:J_real+J_comp] .= (Q[J_real+1:J_real+J_comp] .+ b[n] .* cos(d_comp .* t[n])) .*
+            exp.(-c_comp .* (tref - t[n]))
+        Q[J_real+J_comp+1:J] .= (Q[J_real+J_comp+1:J] .+ b[n] .* sin(d_comp .* t[n])) .*
+            exp.(-c_comp .* (tref - t[n]))
 
         while m < M+1 && (n == N || x[m] <= t[n+1])
-            X[1:J_real] = a_real.*exp(-c_real.*(x[m]-tref))
-            X[J_real+1:J_real+J_comp]  = a_comp.*exp(-c_comp.*(x[m]-tref)).*cos(d_comp.*x[m])
-            X[J_real+1:J_real+J_comp] += b_comp.*exp(-c_comp.*(x[m]-tref)).*sin(d_comp.*x[m])
-            X[J_real+J_comp+1:J]  = a_comp.*exp(-c_comp.*(x[m]-tref)).*sin(d_comp.*x[m])
-            X[J_real+J_comp+1:J] -= b_comp.*exp(-c_comp.*(x[m]-tref)).*cos(d_comp.*x[m])
+            X[1:J_real] .= a_real .* exp.(-c_real .* (x[m] - tref))
+            X[J_real+1:J_real+J_comp] .= a_comp .* exp.(-c_comp .* (x[m] - tref)) .* cos.(d_comp .* x[m]) .+
+                b_comp .* exp.(-c_comp .* (x[m] - tref)) .* sin.(d_comp .* x[m])
+            X[J_real+J_comp+1:J] .= a_comp .* exp.(-c_comp .* (x[m] - tref)) .* sin.(d_comp .* x[m]) .-
+                b_comp .* exp.(-c_comp .* (x[m] - tref)) .* cos.(d_comp .* x[m])
 
             pred[m] = dot(X, Q)
             m += 1
@@ -660,19 +661,19 @@ function predict!(gp::Celerite, t, y, x)
         else
           tref = t[1]
         end
-        Q[1:J_real] += b[n].*a_real
-        Q[1:J_real] = Q[1:J_real].*exp(-c_real.*(t[n]-tref))
-        Q[J_real+1:J_real+J_comp] += b[n].*a_comp.*cos(d_comp.*t[n])
-        Q[J_real+1:J_real+J_comp] += b[n].*b_comp.*sin(d_comp.*t[n])
-        Q[J_real+1:J_real+J_comp] = Q[J_real+1:J_real+J_comp].*exp(-c_comp.*(t[n]-tref))
-        Q[J_real+J_comp+1:J] += b[n].*a_comp.*sin(d_comp.*t[n])
-        Q[J_real+J_comp+1:J] -= b[n].*b_comp.*cos(d_comp.*t[n])
-        Q[J_real+J_comp+1:J] = Q[J_real+J_comp+1:J].*exp(-c_comp.*(t[n]-tref))
+        Q[1:J_real] .= (Q[1:J_real] .+ b[n] .* a_real) .*
+            exp.(-c_real .* (t[n] - tref))
+        Q[J_real+1:J_real+J_comp] .= ((Q[J_real+1:J_real+J_comp] .+ b[n] .* a_comp .* cos.(d_comp .* t[n])) .+
+                                      b[n] .* b_comp .* sin.(d_comp .* t[n])) .*
+                                      exp.(-c_comp .* (t[n] - tref))
+        Q[J_real+J_comp+1:J] .= (Q[J_real+J_comp+1:J] .+ b[n] .* a_comp .* sin.(d_comp .* t[n]) .-
+                                 b[n] .* b_comp .* cos.(d_comp .* t[n])) .*
+                                 exp.(-c_comp .* (t[n] - tref))
 
         while m >= 1 && (n == 1 || x[m] > t[n-1])
-            X[1:J_real] = exp(-c_real.*(tref-x[m]))
-            X[J_real+1:J_real+J_comp] = exp(-c_comp.*(tref-x[m])).*cos(d_comp.*x[m])
-            X[J_real+J_comp+1:J] = exp(-c_comp.*(tref-x[m])).*sin(d_comp.*x[m])
+            X[1:J_real] .= exp.(-c_real .* (tref - x[m]))
+            X[J_real+1:J_real+J_comp] .= exp.(-c_comp .* (tref - x[m])) .* cos.(d_comp .* x[m])
+            X[J_real+J_comp+1:J] .= exp.(-c_comp .* (tref - x[m])) .* sin.(d_comp .* x[m])
 
             pred[m] += dot(X, Q)
             m -= 1

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -8,11 +8,11 @@ function get_terms(term::Term)
 end
 
 function get_real_coefficients(term::Term)
-    return (Array(Float64, 0), Array(Float64, 0))
+    return (Array{Float64}(0), Array{Float64}(0))
 end
 
 function get_complex_coefficients(term::Term)
-    return (Array(Float64, 0), Array(Float64, 0), Array(Float64, 0), Array(Float64, 0))
+    return (Array{Float64}(0), Array{Float64}(0), Array{Float64}(0), Array{Float64}(0))
 end
 
 function get_all_coefficients(term::Term)
@@ -23,13 +23,13 @@ end
 
 function get_value(term::Term, tau)
     coeffs = get_all_coefficients(term)
-    t = abs(tau)
+    t = abs.(tau)
     k = zeros(tau)
     for i in 1:length(coeffs[1])
-        k = k + coeffs[1][i] .* exp(-coeffs[2][i] .* t)
+        k .+= coeffs[1][i] .* exp.(-coeffs[2][i] .* t)
     end
     for i in 1:length(coeffs[3])
-        k = k + (coeffs[3][i].*cos(coeffs[6][i].*t) + coeffs[4][i].*sin(coeffs[6][i].*t)) .* exp(-coeffs[5][i].*t)
+        k .+= (coeffs[3][i] .* cos.(coeffs[6][i] .* t) .+ coeffs[4][i] .* sin.(coeffs[6][i] .* t)) .* exp.(-coeffs[5][i] .* t)
     end
     return k
 end
@@ -60,7 +60,7 @@ function length(term::Term)
 end
 
 function get_parameter_vector(term::Term)
-    return Array(Float64, 0)
+    return Array{Float64}(0)
 end
 
 function set_parameter_vector!(term::Term, vector::Array)
@@ -76,12 +76,12 @@ function get_terms(term::TermSum)
 end
 
 function get_all_coefficients(term_sum::TermSum)
-    a_real = Array(Float64, 0)
-    c_real = Array(Float64, 0)
-    a_complex = Array(Float64, 0)
-    b_complex = Array(Float64, 0)
-    c_complex = Array(Float64, 0)
-    d_complex = Array(Float64, 0)
+    a_real = Array{Float64}(0)
+    c_real = Array{Float64}(0)
+    a_complex = Array{Float64}(0)
+    b_complex = Array{Float64}(0)
+    c_complex = Array{Float64}(0)
+    d_complex = Array{Float64}(0)
     for term in term_sum.terms
         coeffs = get_all_coefficients(term)
 #        a_real = cat(1, a_real, coeffs[1])
@@ -139,8 +139,8 @@ function get_all_coefficients(term_sum::TermProduct)
 
     # First compute real terms
     nr = nr1 * nr2
-    ar = Array(Float64, nr)
-    cr = Array(Float64, nr)
+    ar = Array{Float64}(nr)
+    cr = Array{Float64}(nr)
     gen = product(zip(c1[1], c1[2]), zip(c2[1], c2[2]))
     for (i, ((aj, cj), (ak, ck))) in enumerate(gen)
         ar[i] = aj * ak
@@ -149,10 +149,10 @@ function get_all_coefficients(term_sum::TermProduct)
 
     # Then the complex terms
     nc = nr1 * nc2 + nc1 * nr2 + 2 * nc1 * nc2
-    ac = Array(Float64, nc)
-    bc = Array(Float64, nc)
-    cc = Array(Float64, nc)
-    dc = Array(Float64, nc)
+    ac = Array{Float64}(nc)
+    bc = Array{Float64}(nc)
+    cc = Array{Float64}(nc)
+    dc = Array{Float64}(nc)
 
     # real * complex
     gen = product(zip(c1[1], c1[2]), zip(c2[3:end]...))
@@ -260,7 +260,7 @@ end
 function get_real_coefficients(term::SHOTerm)
     Q = exp(term.log_Q)
     if Q >= 0.5
-        return Array(Float64, 0), Array(Float64, 0)
+        return Array{Float64}(0), Array{Float64}(0)
     end
     S0 = exp(term.log_S0)
     w0 = exp(term.log_omega0)
@@ -274,7 +274,7 @@ end
 function get_complex_coefficients(term::SHOTerm)
     Q = exp(term.log_Q)
     if Q < 0.5
-        return Array(Float64, 0), Array(Float64, 0), Array(Float64, 0), Array(Float64, 0)
+        return Array{Float64}(0), Array{Float64}(0), Array{Float64}(0), Array{Float64}(0)
     end
     S0 = exp(term.log_S0)
     w0 = exp(term.log_omega0)

--- a/src/test_cholesky.jl
+++ b/src/test_cholesky.jl
@@ -48,7 +48,7 @@ ntrial = 2
   N = N_test[itest]
 # Generate some random time data:
   t = sort(rand(N)).*100
-  y0 = sin(t)
+  y0 = sin.(t)
   kernel = RealTerm(log(aj[1]),log(cj[1]))
   for i=2:J0
     kernel = kernel + RealTerm(log(aj[i]),log(cj[i]))
@@ -77,7 +77,7 @@ ntrial = 2
   if N < 2000
     logdetK,K = full_solve(t,y0,aj,bj,cj,dj,yerr)
     println("Determinant: ",logdetK," ",logdet_test)
-    println("Vector: ",maximum(abs(\(K,y0)-apply_inverse(gp,y0))))
+    println("Vector: ", maximum(abs.((K \ y0) .- apply_inverse(gp, y0))))
   end
   println(N_test[itest]," ",time_complex[itest])
   time_prior = time_complex[itest]
@@ -90,7 +90,7 @@ ntrial = 2
 scatter(t,y0)
 plot(tpred,ypred)
 plot(tpred,ypred_full)
-println("Prediction error: ",maximum(abs(ypred-ypred_full)))
+println("Prediction error: ", maximum(abs.(ypred .- ypred_full)))
 
 #loglog(N_test,time_complex)
 data = readdlm("c_speed.txt",',')

--- a/src/test_cholesky_ldlt.jl
+++ b/src/test_cholesky_ldlt.jl
@@ -48,7 +48,7 @@ ntrial = 2
   N = N_test[itest]
 # Generate some random time data:
   t = sort(rand(N)).*100
-  y0 = sin(t)
+  y0 = sin.(t)
   i=1
   if J0 > 0
     kernel = RealTerm(log(aj[i]),log(cj[i]))
@@ -87,7 +87,7 @@ ntrial = 2
   if N < 2000
     logdetK,K = full_solve(t,y0,aj,bj,cj,dj,yerr)
     println("Determinant: ",logdetK," ",logdet_test)
-    println("Vector: ",maximum(abs(\(K,y0)-apply_inverse_ldlt(gp,y0))))
+    println("Vector: ", maximum(abs.((K \ y0) .- apply_inverse_ldlt(gp, y0))))
   end
   println(N_test[itest]," ",time_complex[itest])
   time_prior = time_complex[itest]
@@ -100,7 +100,7 @@ ntrial = 2
 scatter(t,y0)
 plot(tpred,ypred)
 plot(tpred,ypred_full)
-println("Prediction error: ",maximum(abs(ypred-ypred_full)))
+println("Prediction error: ", maximum(abs.(ypred .- ypred_full)))
 
 #loglog(N_test,time_complex)
 data = readdlm("c_speed.txt",',')

--- a/test/test_solver.jl
+++ b/test/test_solver.jl
@@ -4,9 +4,9 @@ import celerite
 function test_solver()
     srand(42)
     N = 100
-    x = sort(10*rand(N))
-    y = sin(x)
-    yerr = 0.01 + 0.01*rand(N)
+    x = sort(10 .* rand(N))
+    y = sin.(x)
+    yerr = 0.01 .+ rand(N) ./ 100
 
     kernel = celerite.RealTerm(0.5, 1.0) + celerite.SHOTerm(0.1, 2.0, -0.5)
     gp = celerite.Celerite(kernel)


### PR DESCRIPTION
Second attempt at cleaning deprecation warnings.  This time, in addition to running `Pkg.test("celerite")` I checked that the semiseparable error and prediction error in `test_cholesky_ldlt.jl` are close to zero (and the determinants computed in the two ways are approximately equal).

For reference, this this the difference with PR #10: https://github.com/giordano/celerite.jl/compare/9d6eafb...3f91f99  I merged multiple lines together (like those `Q[J_real+J_comp+1:J] = ...`) because thanks to loop fusion introduced in Julia 0.6 a single line like this is much faster (though probably a bit less readable..).