### PR TITLE
Use Int instead of Int64

### DIFF
--- a/src/gp.jl
+++ b/src/gp.jl
@@ -10,8 +10,8 @@ type Celerite
     phi::Array{Float64}
     x::Vector{Float64}
     logdet::Float64
-    n::Int64
-    J::Int64
+    n::Int
+    J::Int
 
 #    Celerite(kernel) = new(kernel, false, [], [], [], [], [])
 #    Celerite(kernel) = new(kernel, false, zeros(Float64,0),zeros(Float64,0),zeros(Float64,0,0), zeros(Float64,0,0), zeros(Float64,0,0), zeros(Float64,0,0), zeros(Float64,0),0.0,0,0)

--- a/src/sturms_theorem.jl
+++ b/src/sturms_theorem.jl
@@ -3,7 +3,7 @@
 using Polynomials
 
 function sturms_theorem(x)
-n_lor = round(Int64,length(x)/4)
+n_lor = round(Int, length(x)/4)
 pord = 2*(n_lor-1) + 1
 # Compute coefficients in the numerator & denominator of PSD:
 # The PSD is given by:

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -113,7 +113,7 @@ function get_parameter_vector(term_sum::TermSum)
 end
 
 function set_parameter_vector!(term_sum::TermSum, vector::Array)
-    index::Int64 = 1
+    index = 1
     for term in term_sum.terms
         len = length(term)
         set_parameter_vector!(term, vector[index:index+len-1])


### PR DESCRIPTION
On 64-bit systems, integer literals are of type `Int32`, not `Int64`.  `Int` is a useful alias that is equal to the default integer type on current machine.